### PR TITLE
Add constructor with function pointers for digitalWrite and pinMode + Shifty example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ## Output Library for Arduino - ezOutput
-This library is designed for Arduino, ESP32, ESP8266... to control the states of digital output pins (HIGH, LOW, TOGGLE, PULSE, BLINK_WITHOUT_DELAY). It is easy to use with multiple output pins to control multiple LED, relay... It is designed for not only beginners but also experienced users.
+This library is designed for Arduino, ESP32, ESP8266... to control the states of digital output pins (HIGH, LOW, TOGGLE, PULSE, BLINK_WITHOUT_DELAY). It is easy to use with multiple output pins to control multiple LED, relay... It is designed for not only beginners but also experienced users. The *digitalWrite* and *pinMode* functions can be overwritten to use ezOutput on top of other libraries like [Shifty](https://github.com/johnnyb/Shifty).
 
 **ezOutput** stands for **easy output**, which mean that the library is easy to use.
 
@@ -8,6 +8,7 @@ Features
 * Support HIGH, LOW, PULSE and TOGGLE
 * Support get state of output pin
 * Supports blink without delay
+* Functions for digitalWrite and pinMode are overwritable
 * All functions are non-blocking
 * Easy to use with multiple output pins
 * Support time offset in blink multiple output pins
@@ -15,6 +16,7 @@ Features
 Available Functions
 ----------------------------
 * ezOutput(int pin)
+* ezOutput(int pin, void (*funptr_digitalWrite)(uint8_t, uint8_t), void (*funptr_pinMode)(uint8_t, uint8_t) = nullptr)
 * void high(void)
 * void low(void)
 * void toggle(void)

--- a/examples/09.SingleBlinkWithoutDelayShifty/09.SingleBlinkWithoutDelayShifty.ino
+++ b/examples/09.SingleBlinkWithoutDelayShifty/09.SingleBlinkWithoutDelayShifty.ino
@@ -1,0 +1,37 @@
+/*
+ * Created by ArduinoGetStarted.com
+ *
+ * This example code is in the public domain
+ *
+ * Tutorial page: https://arduinogetstarted.com/tutorials/arduino-output-library
+ *
+ * This example blinks an LED without using delay() function on a shift register using
+ * Shifty https://github.com/johnnyb/Shifty as another abstraction layer. This is a non-blocking example 
+ */
+
+#include <ezOutput.h> // ezOutput library
+#include <Shifty.h> // Shifty library
+
+Shifty shiftRegister; // shift register object
+
+// digitalWrite function for shift register because we can't use a pointer to the non-abstract class member function directly
+void digitalWriteShiftRegister(uint8_t pin, uint8_t state)
+{
+  shiftRegister.writeBit(pin, state);
+}
+
+ezOutput led(0, digitalWriteShiftRegister);  // create ezOutput object that attach to pin 0 of the shift register and overwrites the
+                                             // digitalWrite function with the one from Shifty
+                                             // we don't need to overwrite pinMode because the shift register is an output by defaul
+
+void setup() {
+
+  shiftRegister.setBitCount(8); // 1 shift register with 8 outputs
+  shiftRegister.setPins(10, 11, 12); // shift register connected to data_pin=10, clock_pin=11, latch_pin=12
+
+  led.blink(500, 250); // 500 milliseconds ON, 250 milliseconds OFF
+}
+
+void loop() {
+  led.loop(); // MUST call the led.loop() function in loop()
+}

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=ezOutput
-version=1.2.0
+version=1.3.0
 author=ArduinoGetStarted.com
 maintainer=ArduinoGetStarted.com (ArduinoGetStarted@gmail.com)
 sentence=Output library for Arduino

--- a/src/ezOutput.cpp
+++ b/src/ezOutput.cpp
@@ -31,7 +31,12 @@
 
 #include <ezOutput.h>
 
-ezOutput::ezOutput(int pin) {
+ezOutput::ezOutput(int pin) : ezOutput::ezOutput(pin, digitalWrite, pinMode) {
+}
+
+ezOutput::ezOutput(int pin, void (*funptr_digitalWrite)(uint8_t, uint8_t), void (*funptr_pinMode)(uint8_t, uint8_t)) {
+	_funptr_digitalWrite = funptr_digitalWrite;
+	_funptr_pinMode = funptr_pinMode;
 	_outputPin = pin;
 	_outputState = LOW;
 	_blinkState = BLINK_STATE_DISABLE;
@@ -41,25 +46,28 @@ ezOutput::ezOutput(int pin) {
 	_blinkTimes  = -1;
 	_lastBlinkTime = 0; 
 
-	pinMode(_outputPin, OUTPUT);
+	if (nullptr != _funptr_pinMode)
+	{
+		_funptr_pinMode(_outputPin, OUTPUT);
+	}
 }
 
 void ezOutput::high(void){
 	_blinkState = BLINK_STATE_DISABLE;
 	_outputState = HIGH;
-	digitalWrite(_outputPin, _outputState);
+	_funptr_digitalWrite(_outputPin, _outputState);
 }
 
 void ezOutput::low(void){
 	_blinkState = BLINK_STATE_DISABLE;
 	_outputState = LOW;
-	digitalWrite(_outputPin, _outputState);
+	_funptr_digitalWrite(_outputPin, _outputState);
 }
 
 void ezOutput::toggle(void) {
 	_blinkState = BLINK_STATE_DISABLE;
 	_outputState = (_outputState == LOW) ? HIGH : LOW;
-	digitalWrite(_outputPin, _outputState);
+	_funptr_digitalWrite(_outputPin, _outputState);
 }
 
 void ezOutput::toggle(unsigned long delayTime) {
@@ -141,7 +149,7 @@ void ezOutput::loop(void) {
 
 	if(isBlink) {
 		_outputState = (_outputState == LOW) ? HIGH : LOW;
-		digitalWrite(_outputPin, _outputState);
+		_funptr_digitalWrite(_outputPin, _outputState);
 		_lastBlinkTime = millis();
 		
 		if(_blinkTimes > 0)

--- a/src/ezOutput.h
+++ b/src/ezOutput.h
@@ -50,9 +50,25 @@ class ezOutput
 		unsigned long _startTime;
 		unsigned long _blinkTimes;
 		unsigned long _lastBlinkTime; // the last time the output pin was blinked
+		void (* _funptr_digitalWrite)(uint8_t, uint8_t); //function pointer to digitalWrite function
+		void (* _funptr_pinMode)(uint8_t, uint8_t); //function pointer to pinMode function
 
 	public:
+		/**
+		 * @brief Construct a new ez Output object
+		 * 
+		 * @param pin The IO pin number to use
+		 */
 		ezOutput(int pin);
+
+		/**
+		 * @brief Construct a new ez Output object with function pointers to digitalWrite and pinMode
+		 * 
+		 * @param pin The IO pin number to use
+		 * @param funptr_digitalWrite The digitalWrite function to use
+		 * @param funptr_pinMode The pinMode function to use. Default is nullptr (in this case setting the pinMode to OUTPUT has to be done by the user)
+		 */
+		ezOutput(int pin, void (*funptr_digitalWrite)(uint8_t, uint8_t), void (*funptr_pinMode)(uint8_t, uint8_t) = nullptr);
 		void high(void);
 		void low(void);
 		void toggle(void);


### PR DESCRIPTION
Added overload constructor that allows to overwrite the digitalWrite and pinMode functions used by the library. This way ezOutput  can be used on top of other libraries that offer similar interfaces for setting outputs on for example SN74HC595 shift registers or PCF8574 I²C portextender chips.
This makes ezOutput compatible with any HW output than can be switched by a *void (uint8_t pin, uint8_t level)* function.